### PR TITLE
[BUG #US13 - T1] Filtering not working with empty strings

### DIFF
--- a/products/tests.py
+++ b/products/tests.py
@@ -175,3 +175,17 @@ class ProductsTestCase(TestCase):
         assert request.data[0]['title'] == 'Title'
         assert len(request.data) == 2
 
+    def test_search_empty_strings(self):
+        p = Product.objects.create(title='Title', description='Description', price=1, seller=self.u, category=self.c)
+        p2 = Product.objects.create(title='Pepe', description='Description', price=1, seller=self.u, category=self.c)
+        p.save()
+        p2.save()
+
+        url = "/api/v1/products/?category=&search="
+
+        # Act
+        request = self.client.get(url)
+        print(request.data)
+        assert request.data[0]['title'] == 'Title'
+        assert len(request.data) == 2
+

--- a/products/views.py
+++ b/products/views.py
@@ -45,13 +45,13 @@ class ProductsView(APIView):
             seller = request.GET.get('seller')
             qs = []
 
-            if category is not None:
+            if category is not None and category is not '':
                 qs.append(Q(category__name=category))
-            if search is not None:
+            if search is not None and search is not '':
                 qs.append(Q(title__icontains=search))
-            if id is not None:
+            if id is not None and id is not "":
                 qs.append(Q(id=id))
-            if seller is not None:
+            if seller is not None and seller is not "":
                 qs.append(Q(seller__username=seller))
 
             products = Product.objects.filter(reduce(operator.and_, qs)) if len(qs) > 0 else Product.objects.all()


### PR DESCRIPTION
Empty strings were detected as a filtering parameter so when used, backend didn't return any result.
- Test case added
- Filter fix added

Fix #71 