### PR TITLE
Checks if category in product PATCH request

### DIFF
--- a/products/tests.py
+++ b/products/tests.py
@@ -105,6 +105,21 @@ class ProductsTestCase(TestCase):
 
         self.assertEqual(request.status_code, 404)
 
+    def test_patch_product_set_to_sold(self):
+        p = Product.objects.create(title='Title', description='Description', price=1, seller=self.u,
+                                   category=self.c)
+        p.save()
+
+        data = {
+            'sold': True
+        }
+
+        url = "/api/v1/products/?id=" + str(p.id)
+        request = self.client.patch(url, data)
+
+        self.assertEqual(request.status_code, 200)
+        assert request.data['sold'] == True
+
     def test_get_product_by_id(self):
         Product.objects.create(title='Title', description='Description', price=1, seller=self.u, category=self.c)
         request = self.client.get("/api/v1/products/?id=1", format='json')

--- a/products/views.py
+++ b/products/views.py
@@ -84,7 +84,9 @@ class ProductsView(APIView):
         except products.models.Product.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
-        product.category = Category.objects.get(name=request.data.get('category_name'))
+        if request.data.get('category_name') is not None:
+            product.category = Category.objects.get(name=request.data.get('category_name'))
+
         serialized_product = ProductDataSerializer(instance=product, data=request.data, partial=True)
 
         if serialized_product.is_valid():


### PR DESCRIPTION
Fixes a bug in which PATCH requests that didn't contain the category_name field. The requests returned 500.

Made this parameter not compulsory.